### PR TITLE
Add Week 4 report, Week 5 plan, and expand README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,73 @@
 ![Gradle Build](https://github.com/nu-cs-sqe/course-project-20252603-team-28-20252603/actions/workflows/main.yml/badge.svg)
 [![Open in Codespaces](https://classroom.github.com/assets/launch-codespace-2972f46106e565e64193e422d61a12cf1da4916b45550586e14ef0a7c637dd04.svg)](https://classroom.github.com/open-in-codespaces?assignment_repo_id=23638202)
-# PROJECT NAME
 
-## Contributors
-- Alvin Xu
-- Jace Deng
-- Kyubinn Kim
+# Chess — CS 380 Team 28
 
-## Dependencies
-- JDK 11
-- JUnit 5.10
-- Gradle 8.10
+A 2D chess game built in Java for COMP_SCI 380: Software Quality Engineering (Spring 2026). The project follows a TDD/BDD workflow with continuous integration, branch protection, mutation testing, and BVA-driven test design.
+
+## Project Scope
+
+The game implements the full standard chess ruleset along with one team-defined feature.
+
+**Standard rules**
+- All six piece types (Pawn, Knight, Bishop, Rook, Queen, King) with correct movement and capture
+- Check, checkmate, and stalemate detection
+- Special moves: castling (kingside and queenside), en passant, pawn promotion
+- Draw conditions: stalemate, threefold repetition, fifty-move rule, insufficient material
+- Turn-based play with two human players sharing one machine
+
+**Team-defined feature: Chess clock**
+- Configurable per-side starting time
+- Turn-based countdown that pauses on the inactive player's clock
+- Timeout produces an additional win condition (the player whose clock runs out loses)
+
+## Team
+
+| Member | GitHub |
+| --- | --- |
+| Alvin Xu | [@superalv123](https://github.com/superalv123) |
+| Jace Deng | — |
+| Kyubinn Kim | [@dannykimNU](https://github.com/dannykimNU) |
+
+## Tech Stack
+
+- **Language:** Java 11
+- **Build:** Gradle 8.10 (Kotlin DSL)
+- **Test framework:** JUnit 5.10
+- **CI:** GitHub Actions (`.github/workflows/main.yml`)
+- **Branch protection:** `main` requires a passing CI build and one approving review per pull request
+
+
+## Build and Test
+
+The project uses the Gradle wrapper, so no Gradle installation is required.
+
+```bash
+# Compile and run all tests
+./gradlew build
+
+# Run only the test suite
+./gradlew test
+
+# Clean previous build artifacts
+./gradlew clean
+```
+
+CI runs `./gradlew build` on every pull request and on every push to `main`.
+
+## Run the Game
+
+Run instructions will be added once the application entry point is implemented.
+
+## Development Workflow
+
+1. Create a feature branch off `main` using the format `<author>/<scope>` (for example `kyubinn/knight-movement`).
+2. For each feature, document the BVA in `docs/bva/<feature>.md` before writing code.
+3. Write failing JUnit tests that reflect the BVA, then implement the feature until the tests pass (TDD).
+4. Open a pull request against `main`. CI must pass and at least one teammate must approve before merging.
+5. Update `docs/weekly-reports/report.md` at the end of each week with planning and progress notes.
 
 ## Acknowledgements
-REFERENCES, SOURCE OF HELP ETC
+
+- Course materials and rubric: COMP_SCI 380 Software Quality Engineering, taught by Dr. Yiji Zhang, Northwestern University.
+- Reference textbook: *Clean Code* by Robert C. Martin.

--- a/docs/weekly-reports/report.md
+++ b/docs/weekly-reports/report.md
@@ -6,6 +6,28 @@
 4. [done] Alvin Xu: Week 3 Report
 
 
+# Week 4 (04/20/2026-04/24/2026)
+**Planning and Progress Tracking**:
+1. [done] Kyubinn Kim: Expanded README with project scope (chess ruleset + chess-clock feature), team table, tech stack, repository layout, build/test instructions, and development workflow
+2. [done] Kyubinn Kim: Drafted Week 4 and Week 5 weekly reports capturing team decisions, member responsibilities, and the project timeline
+3. [done] Team: Selected the team-defined "+1 feature" — chess clock (timed game mode with configurable starting time per side, turn-based countdown, and timeout-loss as an additional win condition)
+4. [done] Team: Established team communication — group text thread for day-to-day coordination, plus a weekly meeting with Dr. Yiji on Monday or Tuesday (specific day chosen each week based on member availability)
+5. [done] Team: Delegated initial design responsibilities — Kyubinn Kim will draft a class-design PlantUML diagram covering the chess engine and the chess-clock feature; the team will then review the diagram together, finalize the architecture, and split class-level implementation work from there
+6. [done] Team: Agreed on the project timeline — class design finalized by end of Week 5; implementation and testing of all chess rules and the chess-clock feature complete by end of May. Driver: Jace Deng begins an internship on 06/01 with reduced availability afterward, so the bulk of collaborative work needs to land in May.
+7. [done] Team: Aligned on a deliberate "design-first" approach — agreed it is more valuable to spend Weeks 4–5 reaching a clear shared understanding of what we are building than to start implementation prematurely; this informs the timeline above.
+8. [not started] Kyubinn Kim: Limited availability earlier in the quarter due to personal circumstances; resuming active contribution in Week 4 starting with the PlantUML class design.
+
+
+# Week 5 (04/27/2026-05/01/2026)
+**Planning and Progress Tracking**:
+1. [not started] Kyubinn Kim: Draft initial PlantUML class diagram covering chess engine (Board, Piece hierarchy, Move, Game) and chess-clock feature (Clock, TimeControl)
+2. [not started] Kyubinn Kim: Set up GitHub project board with feature-level issues (per piece, special moves, check/checkmate, draw conditions, chess clock) for team-wide task tracking
+3. [not started] Kyubinn Kim: Draft initial BVA document for the chess-clock feature in `docs/bva/chess-clock.md`
+4. [not started] Team: Review PlantUML diagram in the weekly meeting with Dr. Yiji and finalize class-level architecture
+5. [not started] Team: Split class-implementation responsibilities among Alvin Xu, Jace Deng, and Kyubinn Kim based on the finalized design
+6. [not started] Team: Prepare for Exam 1 (in class, Wednesday 04/29)
+
+
 # Week X (XX/XX/2026-XX/XX/2026) TEMPLATE (You can change the format to whatever the team likes better)
 **Planning and Progress Tracking**:
 1. [done] Person: Task (Links to PR)


### PR DESCRIPTION
## Summary
- Adds Week 4 weekly report capturing team decisions: chess clock as the team-defined +1 feature, weekly Dr. Yiji meeting (Monday/Tuesday based on availability), design-first timeline through end of Week 5, and role delegation
- Adds Week 5 plan covering the PlantUML class diagram, project-board setup, and chess-clock BVA
- Expands README with project scope, team table, tech stack, repository layout, build/test instructions, and contribution workflow

## Project Board
The team project board has been created and populated with 21 backlog issues (#4 through #24) covering design, all six chess pieces, special moves, game-state rules, the chess-clock feature, and infrastructure.

## Timeline Driver
Jace's internship begins 06/01, so the team agreed to lock class-level design by end of Week 5 and concentrate implementation and testing across May.