### PR TITLE
Set up Checkstyle and SpotBugs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,11 @@
+import com.github.spotbugs.snom.Confidence
+import com.github.spotbugs.snom.Effort
+import org.gradle.api.plugins.quality.Checkstyle
+
 plugins {
-    id("java")
+    java
+    checkstyle
+    id("com.github.spotbugs") version "6.4.4"
 }
 
 group = "nu.csse.sqe"
@@ -17,6 +23,27 @@ dependencies {
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(11)
+    }
+}
+
+checkstyle {
+    toolVersion = "10.26.1"
+    configDirectory.set(layout.projectDirectory.dir("config/checkstyle"))
+    isIgnoreFailures = false
+    maxWarnings = 0
+}
+
+spotbugs {
+    ignoreFailures = false
+    showStackTraces = true
+    effort = Effort.MAX
+    reportLevel = Confidence.LOW
+}
+
+tasks.withType<Checkstyle>().configureEach {
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
     }
 }
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <property name="charset" value="UTF-8"/>
+    <property name="severity" value="error"/>
+
+    <module name="NewlineAtEndOfFile"/>
+    <module name="LineLength">
+        <property name="max" value="100"/>
+        <property name="ignorePattern" value="^package .*|^import .*"/>
+    </module>
+
+    <module name="TreeWalker">
+        <module name="AvoidStarImport"/>
+        <module name="OneTopLevelClass"/>
+        <module name="OuterTypeFilename"/>
+        <module name="PackageName"/>
+        <module name="TypeName"/>
+        <module name="MethodName"/>
+        <module name="MemberName"/>
+        <module name="ParameterName"/>
+        <module name="LocalVariableName"/>
+        <module name="ConstantName"/>
+        <module name="ModifierOrder"/>
+        <module name="RedundantModifier"/>
+        <module name="RedundantImport"/>
+        <module name="UnusedImports"/>
+        <module name="ArrayTypeStyle"/>
+        <module name="OneStatementPerLine"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="NeedBraces"/>
+        <module name="LeftCurly"/>
+        <module name="RightCurly"/>
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround"/>
+        <module name="ParenPad"/>
+        <module name="NoWhitespaceBefore"/>
+        <module name="NoWhitespaceAfter"/>
+    </module>
+</module>

--- a/src/test/java/domain/KnightTest.java
+++ b/src/test/java/domain/KnightTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 
 public class KnightTest {
 	@Test
-	public void Constructor_WithWhiteColor_ExpectWhiteKnight(){
+	public void constructorWithWhiteColorExpectWhiteKnight() {
 		Knight knight = new Knight(Color.WHITE);
 		Color expectedColor = Color.WHITE;
 		PieceType expectedType = PieceType.KNIGHT;


### PR DESCRIPTION
## Summary
- Adds Checkstyle to enforce the team Java style standard
- Adds SpotBugs static analysis to catch likely bugs
- Wires both tools into the Gradle check task
- Updates the current Knight test to pass the new checks while allowing tab indentation

Closes #5

## Testing
- bash ./gradlew check