### PR TITLE
Set up Jacoco, Pitest, and other gradle build updates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     checkstyle
     id("com.github.spotbugs") version "6.4.4"
     jacoco
-    //id("info.solidsoft.pitest") version "1.19.0"
+    id("info.solidsoft.pitest") version "1.15.0"
 }
 
 group = "nu.csse.sqe"
@@ -85,12 +85,39 @@ tasks.jacocoTestReport {
 tasks.compileJava {
     options.release = 11
 }
+tasks.build {
+    dependsOn("pitest")
+}
 
 tasks.test {
     useJUnitPlatform()
     finalizedBy(tasks.jacocoTestReport) // report is always generated after tests run
-    //finalizedBy(tasks.pitest)
+    finalizedBy(tasks.pitest)
 }
 tasks.jacocoTestReport {
     dependsOn(tasks.test) // tests are required to run before generating the report
+}
+pitest {
+    targetClasses = setOf("domain.*") //by default "${project.group}.*"
+    targetTests = setOf("domain.*")
+    excludedClasses = setOf(
+        "gui.*",
+        "*View*",
+        "*GUI*",
+        "*Enum*",
+        "Color"
+    )
+    junit5PluginVersion = "1.2.1"
+    pitestVersion = "1.15.0" //not needed when a default PIT version should be used
+
+    threads = 4
+    outputFormats = setOf("HTML")
+    timestampedReports = false
+    testSourceSets.set(listOf(sourceSets.test.get()))
+    mainSourceSets.set(listOf(sourceSets.main.get()))
+    jvmArgs.set(listOf("-Xmx1024m"))
+    useClasspathFile.set(true) //useful with bigger projects on Windows
+    fileExtensionsToFilter.addAll("xml")
+    exportLineCoverage = true
+    // mutationThreshold.set(100) // Uncomment if we need tests to fail when mutations aren't killed
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,9 +3,12 @@ import com.github.spotbugs.snom.Effort
 import org.gradle.api.plugins.quality.Checkstyle
 
 plugins {
+    application
     java
     checkstyle
     id("com.github.spotbugs") version "6.4.4"
+    jacoco
+    //id("info.solidsoft.pitest") version "1.19.0"
 }
 
 group = "nu.csse.sqe"
@@ -47,10 +50,23 @@ tasks.withType<Checkstyle>().configureEach {
     }
 }
 
+tasks.jacocoTestReport {
+    reports {
+        xml.required = false
+        csv.required = false
+        html.outputLocation = layout.buildDirectory.dir("reports/jacoco")
+    }
+}
+
 tasks.compileJava {
     options.release = 11
 }
 
 tasks.test {
     useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport) // report is always generated after tests run
+    //finalizedBy(tasks.pitest)
+}
+tasks.jacocoTestReport {
+    dependsOn(tasks.test) // tests are required to run before generating the report
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,31 @@ tasks.withType<Checkstyle>().configureEach {
         html.required.set(true)
     }
 }
-
+val excluded = listOf(
+    "**/gui/**",
+    "**/*View*",
+    "**/*GUI*",
+    "**/*Enum*",
+    "**/Color.class"
+)
+tasks.jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                counter = "COMPLEXITY"
+                value = "COVEREDRATIO"
+                minimum = "1.0".toBigDecimal()
+            }
+        }
+    }
+    classDirectories.setFrom(
+        files(classDirectories.files.map {
+            fileTree(it) {
+                exclude(excluded)
+            }
+        })
+    )
+}
 tasks.jacocoTestReport {
     reports {
         xml.required = false

--- a/docs/design/coverage.md
+++ b/docs/design/coverage.md
@@ -1,0 +1,4 @@
+# Coverage Policy
+
+The project enforces 100% cyclomatic complexity coverage for all
+non-GUI and non-enum production code using JaCoCo coverage verification.

--- a/docs/design/mutation-testing.md
+++ b/docs/design/mutation-testing.md
@@ -1,0 +1,1 @@
+#Equivalent Mutants


### PR DESCRIPTION
Work in progress — closes #23, closes #24 

## Progress
- [x] JaCoCo plugin added to `build.gradle.kts`
- [x] `./gradlew test jacocoTestReport` produces an HTML report under `build/reports/jacoco/`
- [x] Coverage verification task fails the build if non-GUI/non-enum code drops below 100% line + branch
- [x] Excludes correctly configured for GUI classes and enums
- [ ] CI publishes the coverage report as an artifact
- [x] Brief `docs/design/coverage.md` describing the policy
- [x] PIT plugin added to `build.gradle.kts`
- [x] `./gradlew pitest` runs and produces an HTML report
- [x] Excludes correctly configured for GUI classes and enums
- [ ] Equivalent mutants documented in `docs/design/mutation-testing.md` with justification
- [ ] CI runs mutation testing on PRs and publishes the report as an artifact