### PR TITLE
Knight pure movement (WIP)

### DIFF
--- a/docs/bva/knight.md
+++ b/docs/bva/knight.md
@@ -27,3 +27,45 @@ A knight moves in an L-shape: two squares in one direction and one square in a p
 - **TC1: create white knight** ( ❌ )
   - **State of the system**: color = WHITE
   - **Expected output**: Knight is created; `color()` returns WHITE; `type()` returns KNIGHT
+
+---
+
+## moveCandidates(Square from)
+
+L-shape destinations from the given square on an empty board. No capture or blocking logic.
+
+### Step 1 - Inputs and Outputs
+- Input #1: knight's current square
+- Output #1: set of candidate squares
+- Output #2: exception
+
+### Step 2 - Data Types
+- Input #1: Square (file in [0, 7]; rank in [0, 7])
+- Output #1: Collection (Set)
+- Output #2: Case
+
+### Step 3 - Concrete Values
+- Input #1: file in {0, 4, 7}; rank in {0, 4, 7}; null Square
+- Output #1: set of size 2, 4, or 8
+- Output #2: NullPointerException
+
+### Step 4 - Test Cases
+- **TC1: knight at center returns 8 candidates**
+  - **State of the system**: from = (4, 4)
+  - **Expected output**: (5, 6), (5, 2), (3, 6), (3, 2), (6, 5), (6, 3), (2, 5), (2, 3)
+- **TC2: knight at corner a1 returns 2 candidates**
+  - **State of the system**: from = (0, 0)
+  - **Expected output**: (1, 2), (2, 1)
+- **TC3: knight at corner h8 returns 2 candidates**
+  - **State of the system**: from = (7, 7)
+  - **Expected output**: (6, 5), (5, 6)
+- **TC4: knight at edge a-file middle returns 4 candidates**
+  - **State of the system**: from = (0, 4)
+  - **Expected output**: (1, 6), (1, 2), (2, 5), (2, 3)
+- **TC5: knight at edge first-rank middle returns 4 candidates**
+  - **State of the system**: from = (4, 0)
+  - **Expected output**: (5, 2), (3, 2), (6, 1), (2, 1)
+- **TC6: null Square throws NullPointerException**
+  - **State of the system**: from = null
+  - **Expected output**: NullPointerException
+

--- a/src/main/java/domain/Knight.java
+++ b/src/main/java/domain/Knight.java
@@ -1,6 +1,23 @@
 package domain;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
 public class Knight extends Piece {
+
+	private static final int[][] MOVE_DELTAS = {
+		{1, 2},
+		{1, -2},
+		{-1, 2},
+		{-1, -2},
+		{2, 1},
+		{2, -1},
+		{-2, 1},
+		{-2, -1}
+	};
+
 	public Knight(Color color) {
 		super(color);
 	}
@@ -8,5 +25,15 @@ public class Knight extends Piece {
 	@Override
 	public PieceType type() {
 		return PieceType.KNIGHT;
+	}
+
+	public Set<Square> moveCandidates(Square from) {
+		Objects.requireNonNull(from);
+
+		Set<Square> candidates = new HashSet<>();
+		for (int[] delta : MOVE_DELTAS) {
+			from.offset(delta[0], delta[1]).ifPresent(candidates::add);
+		}
+		return Collections.unmodifiableSet(candidates);
 	}
 }

--- a/src/test/java/domain/KnightTest.java
+++ b/src/test/java/domain/KnightTest.java
@@ -56,5 +56,15 @@ public class KnightTest {
 		Assertions.assertEquals(expected, candidates);
 	}
 
+	@Test
+	public void knightAtEdgeFirstRankReturnsFourMoveCandidates() {
+		Knight knight = new Knight(Color.WHITE);
+		Set<Square> candidates = knight.moveCandidates(Square.of(4, 0));
+
+		Set<Square> expected = Set.of(
+			Square.of(5, 2), Square.of(3, 2),
+			Square.of(6, 1), Square.of(2, 1));
+		Assertions.assertEquals(expected, candidates);
+	}
 
 }

--- a/src/test/java/domain/KnightTest.java
+++ b/src/test/java/domain/KnightTest.java
@@ -26,4 +26,24 @@ public class KnightTest {
 			Square.of(2, 5), Square.of(2, 3));
 		Assertions.assertEquals(expected, candidates);
 	}
+
+	@Test
+	public void knightAtCornerA1ReturnsTwoMoveCandidates() {
+		Knight knight = new Knight(Color.WHITE);
+		Set<Square> candidates = knight.moveCandidates(Square.of(0, 0));
+
+		Set<Square> expected = Set.of(Square.of(1, 2), Square.of(2, 1));
+		Assertions.assertEquals(expected, candidates);
+	}
+
+	@Test
+	public void knightAtCornerH8ReturnsTwoMoveCandidates() {
+		Knight knight = new Knight(Color.WHITE);
+		Set<Square> candidates = knight.moveCandidates(Square.of(7, 7));
+
+		Set<Square> expected = Set.of(Square.of(6, 5), Square.of(5, 6));
+		Assertions.assertEquals(expected, candidates);
+	}
+
+
 }

--- a/src/test/java/domain/KnightTest.java
+++ b/src/test/java/domain/KnightTest.java
@@ -45,5 +45,16 @@ public class KnightTest {
 		Assertions.assertEquals(expected, candidates);
 	}
 
+	@Test
+	public void knightAtEdgeAFileReturnsFourMoveCandidates() {
+		Knight knight = new Knight(Color.WHITE);
+		Set<Square> candidates = knight.moveCandidates(Square.of(0, 4));
+
+		Set<Square> expected = Set.of(
+			Square.of(1, 6), Square.of(1, 2),
+			Square.of(2, 5), Square.of(2, 3));
+		Assertions.assertEquals(expected, candidates);
+	}
+
 
 }

--- a/src/test/java/domain/KnightTest.java
+++ b/src/test/java/domain/KnightTest.java
@@ -1,5 +1,6 @@
 package domain;
 
+import java.util.Set;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -11,5 +12,18 @@ public class KnightTest {
 		PieceType expectedType = PieceType.KNIGHT;
 		Assertions.assertEquals(expectedColor, knight.color());
 		Assertions.assertEquals(expectedType, knight.type());
+	}
+
+	@Test
+	public void knightAtCenterReturnsEightMoveCandidates() {
+		Knight knight = new Knight(Color.WHITE);
+		Set<Square> candidates = knight.moveCandidates(Square.of(4, 4));
+
+		Set<Square> expected = Set.of(
+			Square.of(5, 6), Square.of(5, 2),
+			Square.of(3, 6), Square.of(3, 2),
+			Square.of(6, 5), Square.of(6, 3),
+			Square.of(2, 5), Square.of(2, 3));
+		Assertions.assertEquals(expected, candidates);
 	}
 }

--- a/src/test/java/domain/KnightTest.java
+++ b/src/test/java/domain/KnightTest.java
@@ -67,4 +67,11 @@ public class KnightTest {
 		Assertions.assertEquals(expected, candidates);
 	}
 
+	@Test
+	public void knightMoveCandidatesWithNullSquareThrows() {
+		Knight knight = new Knight(Color.WHITE);
+
+		Assertions.assertThrows(NullPointerException.class,
+			() -> knight.moveCandidates(null));
+	}
 }


### PR DESCRIPTION
Work in progress — pure movement candidates scope for Knight (empty-board L-shape destinations). Capture, friendly-blocking, and check filtering are out of scope here.

Addresses Week 5/6 PM/TA feedback:
- Item #1 (Draft PRs): Opening as Draft from the first commit.
- Item #3 (TDD/BDD workflow): Each commit is one passing test plus the minimum impl that passes it.

## Progress
- [x] BVA section added to docs/bva/knight.md for moveCandidates
- [x] TC1: knight at center returns 8 candidates
- [x] TC2: knight at corner a1 returns 2 candidates
- [x] TC3: knight at corner h8 returns 2 candidates
- [x] TC4: knight at edge a-file returns 4 candidates
- [x] TC5: knight at edge first-rank returns 4 candidates
- [x] TC6: null Square throws NullPointerException