### PR TITLE
Chess clock: TimeControl class

### DIFF
--- a/docs/bva/chess-clock.md
+++ b/docs/bva/chess-clock.md
@@ -31,49 +31,49 @@ The chess clock gives both players a starting amount of time. Only the current p
     - Method(s) under test: `TimeControl(Duration startingTime, Duration increment)`
     - State of the system: starting time = 5 minutes, increment = 0 seconds
     - Expected output: TimeControl is created
-    - Implemented: no
+    - Implemented: yes
 
 - Test Case 2: normal clock with increment
     - Method(s) under test: `TimeControl(Duration startingTime, Duration increment)`
     - State of the system: starting time = 5 minutes, increment = 3 seconds
     - Expected output: TimeControl is created
-    - Implemented: no
+    - Implemented: yes
 
 - Test Case 3: one second starting time
     - Method(s) under test: `TimeControl(Duration startingTime, Duration increment)`
     - State of the system: starting time = 1 second, increment = 0 seconds
     - Expected output: TimeControl is created
-    - Implemented: no
+    - Implemented: yes
 
 - Test Case 4: zero starting time
     - Method(s) under test: `TimeControl(Duration startingTime, Duration increment)`
     - State of the system: starting time = 0 seconds, increment = 0 seconds
     - Expected output: exception
-    - Implemented: no
+    - Implemented: yes
 
 - Test Case 5: negative starting time
     - Method(s) under test: `TimeControl(Duration startingTime, Duration increment)`
     - State of the system: starting time = -1 second, increment = 0 seconds
     - Expected output: exception
-    - Implemented: no
+    - Implemented: yes
 
 - Test Case 6: negative increment
     - Method(s) under test: `TimeControl(Duration startingTime, Duration increment)`
     - State of the system: starting time = 5 minutes, increment = -1 second
     - Expected output: exception
-    - Implemented: no
+    - Implemented: yes
 
 - Test Case 7: null starting time
     - Method(s) under test: `TimeControl(Duration startingTime, Duration increment)`
     - State of the system: starting time = null, increment = 0 seconds
     - Expected output: exception
-    - Implemented: no
+    - Implemented: yes
 
 - Test Case 8: null increment
     - Method(s) under test: `TimeControl(Duration startingTime, Duration increment)`
     - State of the system: starting time = 5 minutes, increment = null
     - Expected output: exception
-    - Implemented: no
+    - Implemented: yes
 
 ---
 

--- a/src/main/java/domain/TimeControl.java
+++ b/src/main/java/domain/TimeControl.java
@@ -1,12 +1,14 @@
 package domain;
 
 import java.time.Duration;
+import java.util.Objects;
 
 public final class TimeControl {
 	private final Duration startingTime;
 	private final Duration increment;
 
 	public TimeControl(Duration startingTime, Duration increment) {
+		Objects.requireNonNull(startingTime);
 		if (startingTime.isZero() || startingTime.isNegative()) {
 			throw new IllegalArgumentException("startingTime must be positive");
 		}

--- a/src/main/java/domain/TimeControl.java
+++ b/src/main/java/domain/TimeControl.java
@@ -9,6 +9,7 @@ public final class TimeControl {
 
 	public TimeControl(Duration startingTime, Duration increment) {
 		Objects.requireNonNull(startingTime);
+		Objects.requireNonNull(increment);
 		if (startingTime.isZero() || startingTime.isNegative()) {
 			throw new IllegalArgumentException("startingTime must be positive");
 		}

--- a/src/main/java/domain/TimeControl.java
+++ b/src/main/java/domain/TimeControl.java
@@ -10,6 +10,9 @@ public final class TimeControl {
 		if (startingTime.isZero() || startingTime.isNegative()) {
 			throw new IllegalArgumentException("startingTime must be positive");
 		}
+		if (increment.isNegative()) {
+			throw new IllegalArgumentException("increment must not be negative");
+		}
 		this.startingTime = startingTime;
 		this.increment = increment;
 	}

--- a/src/main/java/domain/TimeControl.java
+++ b/src/main/java/domain/TimeControl.java
@@ -7,6 +7,9 @@ public final class TimeControl {
 	private final Duration increment;
 
 	public TimeControl(Duration startingTime, Duration increment) {
+		if (startingTime.isZero() || startingTime.isNegative()) {
+			throw new IllegalArgumentException("startingTime must be positive");
+		}
 		this.startingTime = startingTime;
 		this.increment = increment;
 	}

--- a/src/main/java/domain/TimeControl.java
+++ b/src/main/java/domain/TimeControl.java
@@ -1,0 +1,21 @@
+package domain;
+
+import java.time.Duration;
+
+public final class TimeControl {
+	private final Duration startingTime;
+	private final Duration increment;
+
+	public TimeControl(Duration startingTime, Duration increment) {
+		this.startingTime = startingTime;
+		this.increment = increment;
+	}
+
+	public Duration startingTime() {
+		return startingTime;
+	}
+
+	public Duration increment() {
+		return increment;
+	}
+}

--- a/src/test/java/domain/TimeControlTest.java
+++ b/src/test/java/domain/TimeControlTest.java
@@ -44,4 +44,10 @@ public class TimeControlTest {
 		Assertions.assertThrows(IllegalArgumentException.class,
 			() -> new TimeControl(Duration.ofMinutes(5), Duration.ofSeconds(-1)));
 	}
+
+	@Test
+	public void nullStartingTimeThrows() {
+		Assertions.assertThrows(NullPointerException.class,
+			() -> new TimeControl(null, Duration.ZERO));
+	}
 }

--- a/src/test/java/domain/TimeControlTest.java
+++ b/src/test/java/domain/TimeControlTest.java
@@ -20,4 +20,10 @@ public class TimeControlTest {
 		Assertions.assertEquals(Duration.ofMinutes(5), tc.startingTime());
 		Assertions.assertEquals(Duration.ofSeconds(3), tc.increment());
 	}
+
+	@Test
+	public void oneSecondStartingTimeIsCreated() {
+		TimeControl tc = new TimeControl(Duration.ofSeconds(1), Duration.ZERO);
+		Assertions.assertEquals(Duration.ofSeconds(1), tc.startingTime());
+	}
 }

--- a/src/test/java/domain/TimeControlTest.java
+++ b/src/test/java/domain/TimeControlTest.java
@@ -38,4 +38,10 @@ public class TimeControlTest {
 		Assertions.assertThrows(IllegalArgumentException.class,
 			() -> new TimeControl(Duration.ofSeconds(-1), Duration.ZERO));
 	}
+
+	@Test
+	public void negativeIncrementThrows() {
+		Assertions.assertThrows(IllegalArgumentException.class,
+			() -> new TimeControl(Duration.ofMinutes(5), Duration.ofSeconds(-1)));
+	}
 }

--- a/src/test/java/domain/TimeControlTest.java
+++ b/src/test/java/domain/TimeControlTest.java
@@ -50,4 +50,10 @@ public class TimeControlTest {
 		Assertions.assertThrows(NullPointerException.class,
 			() -> new TimeControl(null, Duration.ZERO));
 	}
+
+	@Test
+	public void nullIncrementThrows() {
+		Assertions.assertThrows(NullPointerException.class,
+			() -> new TimeControl(Duration.ofMinutes(5), null));
+	}
 }

--- a/src/test/java/domain/TimeControlTest.java
+++ b/src/test/java/domain/TimeControlTest.java
@@ -1,0 +1,16 @@
+package domain;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TimeControlTest {
+
+	@Test
+	public void normalClockWithNoIncrementIsCreated() {
+		TimeControl tc = new TimeControl(Duration.ofMinutes(5), Duration.ZERO);
+		Assertions.assertEquals(Duration.ofMinutes(5), tc.startingTime());
+		Assertions.assertEquals(Duration.ZERO, tc.increment());
+	}
+}

--- a/src/test/java/domain/TimeControlTest.java
+++ b/src/test/java/domain/TimeControlTest.java
@@ -26,4 +26,10 @@ public class TimeControlTest {
 		TimeControl tc = new TimeControl(Duration.ofSeconds(1), Duration.ZERO);
 		Assertions.assertEquals(Duration.ofSeconds(1), tc.startingTime());
 	}
+
+	@Test
+	public void zeroStartingTimeThrows() {
+		Assertions.assertThrows(IllegalArgumentException.class,
+			() -> new TimeControl(Duration.ZERO, Duration.ZERO));
+	}
 }

--- a/src/test/java/domain/TimeControlTest.java
+++ b/src/test/java/domain/TimeControlTest.java
@@ -13,4 +13,11 @@ public class TimeControlTest {
 		Assertions.assertEquals(Duration.ofMinutes(5), tc.startingTime());
 		Assertions.assertEquals(Duration.ZERO, tc.increment());
 	}
+
+	@Test
+	public void normalClockWithIncrementIsCreated() {
+		TimeControl tc = new TimeControl(Duration.ofMinutes(5), Duration.ofSeconds(3));
+		Assertions.assertEquals(Duration.ofMinutes(5), tc.startingTime());
+		Assertions.assertEquals(Duration.ofSeconds(3), tc.increment());
+	}
 }

--- a/src/test/java/domain/TimeControlTest.java
+++ b/src/test/java/domain/TimeControlTest.java
@@ -32,4 +32,10 @@ public class TimeControlTest {
 		Assertions.assertThrows(IllegalArgumentException.class,
 			() -> new TimeControl(Duration.ZERO, Duration.ZERO));
 	}
+
+	@Test
+	public void negativeStartingTimeThrows() {
+		Assertions.assertThrows(IllegalArgumentException.class,
+			() -> new TimeControl(Duration.ofSeconds(-1), Duration.ZERO));
+	}
 }


### PR DESCRIPTION
TimeControl value class for the chess clock feature. Covers the BVA at docs/bva/chess-clock.md TC1-TC8.

Addresses Week 5/6 PM/TA feedback:
- Item #1 (Draft PRs): Opened as Draft from the first commit.
- Item #3 (TDD/BDD workflow): Each commit is one passing test plus the minimum impl that passes it. Impl grew across 5 commits as new TCs demanded it.

ChessClock (TC9-TC32) will land in a follow-up PR after this is merged.

## Test Cases (all green)
- [x] TC1: normal clock with no increment
- [x] TC2: normal clock with increment
- [x] TC3: one second starting time
- [x] TC4: zero starting time throws
- [x] TC5: negative starting time throws
- [x] TC6: negative increment throws
- [x] TC7: null starting time throws
- [x] TC8: null increment throws