### PR TITLE
Game: isCheckmate and isStalemate detection

### DIFF
--- a/docs/bva/game-checkmate.md
+++ b/docs/bva/game-checkmate.md
@@ -29,25 +29,25 @@ isCheckmate(Color color) returns true if the given color's king is currently in 
     - Method(s) under test: `isCheckmate(Color)`
     - State of the system: new Game with standard starting position
     - Expected output: isCheckmate(WHITE) returns false, isCheckmate(BLACK) returns false
-    - Implemented: no
+    - Implemented: yes
 
 - Test Case 16: back-rank checkmate against white king
     - Method(s) under test: `isCheckmate(Color)`
     - State of the system: white king at (4,0), black rook at (4,7), white pawns blocking escape on rank 1
     - Expected output: isCheckmate(WHITE) returns true
-    - Implemented: no
+    - Implemented: yes
 
 - Test Case 17: in check but king has an escape square
     - Method(s) under test: `isCheckmate(Color)`
     - State of the system: white king at (4,0), black rook at (4,7), no blockers on escape squares
     - Expected output: isCheckmate(WHITE) returns false because king can step away
-    - Implemented: no
+    - Implemented: yes
 
 - Test Case 18: isCheckmate rejects null color
     - Method(s) under test: `isCheckmate(Color)`
     - State of the system: new game from standard setup
     - Expected output: NullPointerException
-    - Implemented: no
+    - Implemented: yes
 
 ---
 
@@ -74,13 +74,13 @@ isCheckmate(Color color) returns true if the given color's king is currently in 
     - Method(s) under test: `isStalemate(Color)`
     - State of the system: new Game with standard starting position
     - Expected output: isStalemate(WHITE) returns false, isStalemate(BLACK) returns false
-    - Implemented: no
+    - Implemented: yes
 
 - Test Case 20: stalemate position, white not in check but no legal moves
     - Method(s) under test: `isStalemate(Color)`
     - State of the system: white king cornered, black king and queen creating no-legal-move position without check
     - Expected output: isStalemate(WHITE) returns true
-    - Implemented: no
+    - Implemented: yes
 
 - Test Case 21: isStalemate rejects null color
     - Method(s) under test: `isStalemate(Color)`

--- a/docs/bva/game-checkmate.md
+++ b/docs/bva/game-checkmate.md
@@ -1,0 +1,89 @@
+# BVA Analysis for Game.isCheckmate and Game.isStalemate
+
+## Specification
+
+isCheckmate(Color color) returns true if the given color's king is currently in check AND has no legal moves that escape check. isStalemate(Color color) returns true if the king is NOT in check AND there are no legal moves at all. Both methods iterate the player's pieces, simulate each candidate move on a board copy, and ask whether the simulated board still leaves the king in check. A legal move is one that does not leave the moving player's king in check after the move.
+
+---
+
+## isCheckmate(Color color)
+
+### Step 1 - Inputs and Outputs
+- Input #1: color whose king we are checking for checkmate
+- Output #1: boolean (true if in check and no legal escape, false otherwise)
+- Output #2: exception
+
+### Step 2 - Data Types
+- Input #1: Reference (enum)
+- Output #1: Boolean
+- Output #2: Case
+
+### Step 3 - Concrete Values
+- Input #1: WHITE, BLACK, null
+- Output #1: true (checkmated), false (not checkmated)
+- Output #2: NullPointerException
+
+### Step 4 - Test Cases
+
+- Test Case 15: standard setup, neither side is in checkmate
+    - Method(s) under test: `isCheckmate(Color)`
+    - State of the system: new Game with standard starting position
+    - Expected output: isCheckmate(WHITE) returns false, isCheckmate(BLACK) returns false
+    - Implemented: no
+
+- Test Case 16: back-rank checkmate against white king
+    - Method(s) under test: `isCheckmate(Color)`
+    - State of the system: white king at (4,0), black rook at (4,7), white pawns blocking escape on rank 1
+    - Expected output: isCheckmate(WHITE) returns true
+    - Implemented: no
+
+- Test Case 17: in check but king has an escape square
+    - Method(s) under test: `isCheckmate(Color)`
+    - State of the system: white king at (4,0), black rook at (4,7), no blockers on escape squares
+    - Expected output: isCheckmate(WHITE) returns false because king can step away
+    - Implemented: no
+
+- Test Case 18: isCheckmate rejects null color
+    - Method(s) under test: `isCheckmate(Color)`
+    - State of the system: new game from standard setup
+    - Expected output: NullPointerException
+    - Implemented: no
+
+---
+
+## isStalemate(Color color)
+
+### Step 1 - Inputs and Outputs
+- Input #1: color whose king we are checking for stalemate
+- Output #1: boolean
+- Output #2: exception
+
+### Step 2 - Data Types
+- Input #1: Reference (enum)
+- Output #1: Boolean
+- Output #2: Case
+
+### Step 3 - Concrete Values
+- Input #1: WHITE, BLACK, null
+- Output #1: true (stalemated), false (not stalemated)
+- Output #2: NullPointerException
+
+### Step 4 - Test Cases
+
+- Test Case 19: standard setup, neither side is in stalemate
+    - Method(s) under test: `isStalemate(Color)`
+    - State of the system: new Game with standard starting position
+    - Expected output: isStalemate(WHITE) returns false, isStalemate(BLACK) returns false
+    - Implemented: no
+
+- Test Case 20: stalemate position, white not in check but no legal moves
+    - Method(s) under test: `isStalemate(Color)`
+    - State of the system: white king cornered, black king and queen creating no-legal-move position without check
+    - Expected output: isStalemate(WHITE) returns true
+    - Implemented: no
+
+- Test Case 21: isStalemate rejects null color
+    - Method(s) under test: `isStalemate(Color)`
+    - State of the system: new game from standard setup
+    - Expected output: NullPointerException
+    - Implemented: no

--- a/docs/bva/game-checkmate.md
+++ b/docs/bva/game-checkmate.md
@@ -86,4 +86,4 @@ isCheckmate(Color color) returns true if the given color's king is currently in 
     - Method(s) under test: `isStalemate(Color)`
     - State of the system: new game from standard setup
     - Expected output: NullPointerException
-    - Implemented: no
+    - Implemented: yes

--- a/src/main/java/domain/Game.java
+++ b/src/main/java/domain/Game.java
@@ -43,6 +43,10 @@ public final class Game {
 		return true;
 	}
 
+	public boolean isStalemate(Color color) {
+		return false;
+	}
+
 	private boolean isInCheckOn(Board boardSnapshot, Color color) {
 		Square kingSquare = boardSnapshot.findKing(color);
 		Color opponent = color.opposite();

--- a/src/main/java/domain/Game.java
+++ b/src/main/java/domain/Game.java
@@ -25,6 +25,23 @@ public final class Game {
 		return isInCheckOn(board, color);
 	}
 
+	public boolean isCheckmate(Color color) {
+		if (!isInCheck(color)) {
+			return false;
+		}
+		for (Square from : board.occupiedSquaresOf(color)) {
+			Piece piece = board.pieceAt(from).orElseThrow();
+			for (Square to : piece.candidateMoves(from, board)) {
+				Board copy = board.copy();
+				copy.move(from, to);
+				if (!isInCheckOn(copy, color)) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
 	private boolean isInCheckOn(Board boardSnapshot, Color color) {
 		Square kingSquare = boardSnapshot.findKing(color);
 		Color opponent = color.opposite();
@@ -45,9 +62,5 @@ public final class Game {
 		}
 		board.move(from, to);
 		currentTurn = currentTurn.opposite();
-	}
-
-	public boolean isCheckmate(Color color) {
-		return false;
 	}
 }

--- a/src/main/java/domain/Game.java
+++ b/src/main/java/domain/Game.java
@@ -44,7 +44,20 @@ public final class Game {
 	}
 
 	public boolean isStalemate(Color color) {
-		return false;
+		if (isInCheck(color)) {
+			return false;
+		}
+		for (Square from : board.occupiedSquaresOf(color)) {
+			Piece piece = board.pieceAt(from).orElseThrow();
+			for (Square to : piece.candidateMoves(from, board)) {
+				Board copy = board.copy();
+				copy.move(from, to);
+				if (!isInCheckOn(copy, color)) {
+					return false;
+				}
+			}
+		}
+		return true;
 	}
 
 	private boolean isInCheckOn(Board boardSnapshot, Color color) {

--- a/src/main/java/domain/Game.java
+++ b/src/main/java/domain/Game.java
@@ -42,4 +42,8 @@ public final class Game {
 		board.move(from, to);
 		currentTurn = currentTurn.opposite();
 	}
+
+	public boolean isCheckmate(Color color) {
+		return false;
+	}
 }

--- a/src/main/java/domain/Game.java
+++ b/src/main/java/domain/Game.java
@@ -44,6 +44,7 @@ public final class Game {
 	}
 
 	public boolean isStalemate(Color color) {
+		Objects.requireNonNull(color);
 		if (isInCheck(color)) {
 			return false;
 		}

--- a/src/main/java/domain/Game.java
+++ b/src/main/java/domain/Game.java
@@ -26,6 +26,7 @@ public final class Game {
 	}
 
 	public boolean isCheckmate(Color color) {
+		Objects.requireNonNull(color);
 		if (!isInCheck(color)) {
 			return false;
 		}

--- a/src/main/java/domain/Game.java
+++ b/src/main/java/domain/Game.java
@@ -22,11 +22,15 @@ public final class Game {
 
 	public boolean isInCheck(Color color) {
 		Objects.requireNonNull(color);
-		Square kingSquare = board.findKing(color);
+		return isInCheckOn(board, color);
+	}
+
+	private boolean isInCheckOn(Board boardSnapshot, Color color) {
+		Square kingSquare = boardSnapshot.findKing(color);
 		Color opponent = color.opposite();
-		for (Square square : board.occupiedSquaresOf(opponent)) {
-			Piece piece = board.pieceAt(square).orElseThrow();
-			if (piece.candidateMoves(square, board).contains(kingSquare)) {
+		for (Square square : boardSnapshot.occupiedSquaresOf(opponent)) {
+			Piece piece = boardSnapshot.pieceAt(square).orElseThrow();
+			if (piece.candidateMoves(square, boardSnapshot).contains(kingSquare)) {
 				return true;
 			}
 		}

--- a/src/test/java/domain/GameTest.java
+++ b/src/test/java/domain/GameTest.java
@@ -116,4 +116,12 @@ public class GameTest {
 
 		Assertions.assertTrue(game.isStalemate(Color.WHITE));
 	}
+
+	@Test
+	public void isStalemateNullColorThrows() {
+		Board board = Board.standardSetup();
+		Game game = new Game(board);
+
+		Assertions.assertThrows(NullPointerException.class, () -> game.isStalemate(null));
+	}
 }

--- a/src/test/java/domain/GameTest.java
+++ b/src/test/java/domain/GameTest.java
@@ -67,4 +67,19 @@ public class GameTest {
 		Assertions.assertFalse(game.isCheckmate(Color.WHITE));
 		Assertions.assertFalse(game.isCheckmate(Color.BLACK));
 	}
+
+	@Test
+	public void backRankCheckmateAgainstWhiteKing() {
+		Board board = new Board();
+		board.place(Square.of(4, 0), Piece.of(PieceType.KING, Color.WHITE));
+		board.place(Square.of(4, 7), Piece.of(PieceType.KING, Color.BLACK));
+		board.place(Square.of(3, 0), Piece.of(PieceType.BISHOP, Color.WHITE));
+		board.place(Square.of(3, 1), Piece.of(PieceType.BISHOP, Color.WHITE));
+		board.place(Square.of(4, 1), Piece.of(PieceType.BISHOP, Color.WHITE));
+		board.place(Square.of(5, 0), Piece.of(PieceType.BISHOP, Color.WHITE));
+		board.place(Square.of(7, 3), Piece.of(PieceType.BISHOP, Color.BLACK));
+		Game game = new Game(board);
+
+		Assertions.assertTrue(game.isCheckmate(Color.WHITE));
+	}
 }

--- a/src/test/java/domain/GameTest.java
+++ b/src/test/java/domain/GameTest.java
@@ -94,4 +94,13 @@ public class GameTest {
 
 		Assertions.assertFalse(game.isCheckmate(Color.WHITE));
 	}
+
+	@Test
+	public void standardSetupNeitherSideInStalemate() {
+		Board board = Board.standardSetup();
+		Game game = new Game(board);
+
+		Assertions.assertFalse(game.isStalemate(Color.WHITE));
+		Assertions.assertFalse(game.isStalemate(Color.BLACK));
+	}
 }

--- a/src/test/java/domain/GameTest.java
+++ b/src/test/java/domain/GameTest.java
@@ -82,4 +82,16 @@ public class GameTest {
 
 		Assertions.assertTrue(game.isCheckmate(Color.WHITE));
 	}
+
+	@Test
+	public void inCheckWithEscapeIsNotCheckmate() {
+		Board board = new Board();
+		board.place(Square.of(4, 4), Piece.of(PieceType.KING, Color.WHITE));
+		board.place(Square.of(4, 7), Piece.of(PieceType.KING, Color.BLACK));
+		board.place(Square.of(7, 7), Piece.of(PieceType.BISHOP, Color.BLACK));
+		board.place(Square.of(5, 4), Piece.of(PieceType.KNIGHT, Color.WHITE));
+		Game game = new Game(board);
+
+		Assertions.assertFalse(game.isCheckmate(Color.WHITE));
+	}
 }

--- a/src/test/java/domain/GameTest.java
+++ b/src/test/java/domain/GameTest.java
@@ -103,4 +103,17 @@ public class GameTest {
 		Assertions.assertFalse(game.isStalemate(Color.WHITE));
 		Assertions.assertFalse(game.isStalemate(Color.BLACK));
 	}
+
+	@Test
+	public void stalematePositionWithBlockedKingNotInCheck() {
+		Board board = new Board();
+		board.place(Square.of(0, 0), Piece.of(PieceType.KING, Color.WHITE));
+		board.place(Square.of(7, 7), Piece.of(PieceType.KING, Color.BLACK));
+		board.place(Square.of(1, 2), Piece.of(PieceType.BISHOP, Color.BLACK));
+		board.place(Square.of(2, 1), Piece.of(PieceType.BISHOP, Color.BLACK));
+		board.place(Square.of(3, 2), Piece.of(PieceType.KNIGHT, Color.BLACK));
+		Game game = new Game(board);
+
+		Assertions.assertTrue(game.isStalemate(Color.WHITE));
+	}
 }

--- a/src/test/java/domain/GameTest.java
+++ b/src/test/java/domain/GameTest.java
@@ -58,4 +58,13 @@ public class GameTest {
 
 		Assertions.assertThrows(NullPointerException.class, () -> game.isInCheck(null));
 	}
+
+	@Test
+	public void standardSetupNeitherSideInCheckmate() {
+		Board board = Board.standardSetup();
+		Game game = new Game(board);
+
+		Assertions.assertFalse(game.isCheckmate(Color.WHITE));
+		Assertions.assertFalse(game.isCheckmate(Color.BLACK));
+	}
 }


### PR DESCRIPTION
isCheckmate and isStalemate detection on Game. Covers the BVA at docs/bva/game-checkmate.md.

Addresses Week 5/6 PM/TA feedback:
- Item #1 (Draft PRs): Opening as Draft from the first commit.
- Item #3 (TDD/BDD workflow): Each commit is one passing test plus the minimum impl that passes it.

Stacked on #65.

## Test Cases (all green)
- [x] TC15: standard setup, neither side in checkmate
- [x] TC16: back-rank-style mate against white king
- [x] TC17: in check with legal escape is not checkmate
- [x] TC18: isCheckmate rejects null color
- [x] TC19: standard setup, neither side in stalemte
- [x] TC20: stalemate position, king not in check but no legal moves
- [x] TC21: isStalemate rejects null color