### PR TITLE
docs: scope down to what we built

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,23 @@
 
 # Chess — CS 380 Team 28
 
-A 2D chess game built in Java for COMP_SCI 380: Software Quality Engineering (Spring 2026). The project follows a TDD/BDD workflow with continuous integration, branch protection, mutation testing, and BVA-driven test design.
+A 2D chess game built in Java for COMP_SCI 380: Software Quality Engineering (Spring 2026). Most features start with a BVA doc and JUnit tests. PIT runs mutation testing, and CI gates every PR to main.
 
 ## Project Scope
 
-The game implements the full standard chess ruleset along with one team-defined feature.
+The game covers standard chess rules plus a chess clock.
 
 **Standard rules**
 - All six piece types (Pawn, Knight, Bishop, Rook, Queen, King) with correct movement and capture
 - Check, checkmate, and stalemate detection
-- Special moves: castling (kingside and queenside), en passant, pawn promotion
-- Draw conditions: stalemate, threefold repetition, fifty-move rule, insufficient material
-- Turn-based play with two human players sharing one machine
+- Pawn promotion
+
+Scope REVISED: not adding castling, en passant, threefold repetition, fifty-move rule, or insufficient material draws.
 
 **Team-defined feature: Chess clock**
-- Configurable per-side starting time
-- Turn-based countdown that pauses on the inactive player's clock
-- Timeout produces an additional win condition (the player whose clock runs out loses)
+- Each side has a starting time (configurable)
+- The active player's clock ticks down. The other player's pauses.
+- If your clock hits zero, you lose.
 
 ## Team
 
@@ -61,11 +61,7 @@ Run instructions will be added once the application entry point is implemented.
 
 ## Development Workflow
 
-1. Create a feature branch off `main` using the format `<author>/<scope>` (for example `kyubinn/knight-movement`).
-2. For each feature, document the BVA in `docs/bva/<feature>.md` before writing code.
-3. Write failing JUnit tests that reflect the BVA, then implement the feature until the tests pass (TDD).
-4. Open a pull request against `main`. CI must pass and at least one teammate must approve before merging.
-5. Update `docs/weekly-reports/report.md` at the end of each week with planning and progress notes.
+All changes go through pull requests to `main`. CI must pass and at least one teammate must approve before merging.
 
 ## Acknowledgements
 

--- a/docs/requirements/game-rules.md
+++ b/docs/requirements/game-rules.md
@@ -1,1 +1,47 @@
-Please either include the complete game rules within this document or provide a direct link to them.
+# Game Rules
+
+The rules implemented in this project. Matches the README scope.
+
+## Board
+
+Standard 8x8 board. White at the bottom (rows 0-1), black at the top (rows 6-7). Squares are 0-indexed in code (`(row, col)` from `(0,0)` to `(7,7)`).
+
+## Pieces
+
+Six piece types, both colors:
+- Pawn: moves 1 forward, 2 from starting row, captures diagonally
+- Rook: any number of squares orthogonal, stops on first piece
+- Knight: L-shape (2+1), can jump over pieces
+- Bishop: any number of squares diagonal, stops on first piece
+- Queen: rook + bishop moves combined
+- King: 1 square in any direction
+
+All pieces can capture an opposing piece by landing on its square. None can land on a friendly piece.
+
+## Turn order
+
+White moves first. Players alternate. Only one move per turn.
+
+## Check
+
+A king is in check if an opposing piece could capture it on the next move. The player in check has to escape it on the next move. Options are moving the king, blocking, or capturing whatever's attacking.
+
+## Checkmate
+
+If the player in check has no legal move to escape, that's checkmate. The other side wins.
+
+## Stalemate
+
+If the player to move is NOT in check but has no legal moves, that's stalemate. The game is a draw.
+
+## Pawn promotion
+
+When a pawn reaches the back rank (row 7 for white, row 0 for black), the player picks Queen, Rook, Bishop, or Knight. The pawn is replaced with the chosen piece, same color.
+
+## Chess clock
+
+Both sides start with the same configurable time. The active player's clock ticks down. The other side's clock pauses. If your clock hits zero, you lose.
+
+## Out of scope
+
+Castling, en passant, threefold repetition, fifty-move rule, and insufficient material draws are not implemented.


### PR DESCRIPTION
README and requirements doc updated to match what we actually shipped. Castling, en passant, and the complex draw rules are out of scope.

Addresses Week 5/6 PM/TA feedback:
- Item #1 (Draft PRs): Opening as Draft from the first commit.