### PR TITLE
test(piece): cover base candidateMoves

### DIFF
--- a/docs/bva/piece.md
+++ b/docs/bva/piece.md
@@ -61,3 +61,37 @@ while `Piece.of()` creates the correct concrete piece class from a `PieceType`.
 - **TC7: return concrete piece type** ( implemented in TC1 )
 	- **State of the system**: piece created through `Piece.of()`
 	- **Expected output**: `type()` returns the matching PieceType
+
+## candidateMoves(Square from, Board board)
+
+### Step 1 - Inputs and Outputs
+- Input #1: source square
+- Input #2: board state
+- Output #1: set of candidate destination squares
+- Output #2: exception
+
+### Step 2 - Data Types
+- Input #1: Reference
+- Input #2: Reference
+- Output #1: Collection
+- Output #2: Case
+
+### Step 3 - Concrete Values
+- Source square: corner square (0, 0)
+- Board state: empty board, null
+- Capture state: opponent piece on diagonal forward square, friendly piece on
+  diagonal forward square
+- Output: collection of candidate moves
+
+### Step 4 - Test Cases
+- **TC8: null source square is rejected** ( ✅ )
+	- **State of the system**: source square = null, board = empty board
+	- **Expected output**: exception
+
+- **TC9: null board is rejected** ( ✅ )
+	- **State of the system**: source square = (0, 0), board = null
+	- **Expected output**: exception
+
+- **TC10: candidate moves for default piece is empty** ( ✅ )
+	- **State of the system**: source square = (0, 0), board = empty board
+	- **Expected output**: no candidate moves

--- a/src/test/java/domain/PieceTest.java
+++ b/src/test/java/domain/PieceTest.java
@@ -63,4 +63,13 @@ public class PieceTest {
 		Assertions.assertThrows(NullPointerException.class,
 			() -> piece.candidateMoves(Square.of(0, 0), null));
 	}
+
+	@Test
+	public void candidateMovesDefaultReturnsEmpty() {
+		Piece piece = new StubPiece(Color.WHITE);
+		Board board = new Board();
+		Set<Square> moves = piece.candidateMoves(Square.of(0, 0), board);
+
+		Assertions.assertTrue(moves.isEmpty());
+	}
 }

--- a/src/test/java/domain/PieceTest.java
+++ b/src/test/java/domain/PieceTest.java
@@ -55,4 +55,12 @@ public class PieceTest {
 		Assertions.assertThrows(NullPointerException.class,
 			() -> piece.candidateMoves(null, board));
 	}
+
+	@Test
+	public void candidateMovesNullBoardThrows() {
+		Piece piece = new StubPiece(Color.WHITE);
+
+		Assertions.assertThrows(NullPointerException.class,
+			() -> piece.candidateMoves(Square.of(0, 0), null));
+	}
 }

--- a/src/test/java/domain/PieceTest.java
+++ b/src/test/java/domain/PieceTest.java
@@ -10,8 +10,12 @@ public class PieceTest {
 	// stub that inherits candidateMoves without overiding it so the base
 	// methods null guards and default empty return actually run in the tests
 	private static class StubPiece extends Piece {
-		StubPiece(Color color) { super(color); }
-		@Override public PieceType type() { return PieceType.PAWN; }
+		StubPiece(Color color) {
+			super(color);
+		}
+		@Override public PieceType type() {
+			return PieceType.PAWN;
+		}
 	}
 
 	@Test

--- a/src/test/java/domain/PieceTest.java
+++ b/src/test/java/domain/PieceTest.java
@@ -46,4 +46,13 @@ public class PieceTest {
 				NullPointerException.class,
 				() -> Piece.of(PieceType.PAWN, null));
 	}
+
+	@Test
+	public void candidateMovesNullFromThrows() {
+		Piece piece = new StubPiece(Color.WHITE);
+		Board board = new Board();
+
+		Assertions.assertThrows(NullPointerException.class,
+			() -> piece.candidateMoves(null, board));
+	}
 }

--- a/src/test/java/domain/PieceTest.java
+++ b/src/test/java/domain/PieceTest.java
@@ -3,7 +3,17 @@ package domain;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+
 public class PieceTest {
+
+	// stub that inherits candidateMoves without overiding it so the base
+	// methods null guards and default empty return actually run in the tests
+	private static class StubPiece extends Piece {
+		StubPiece(Color color) { super(color); }
+		@Override public PieceType type() { return PieceType.PAWN; }
+	}
+
 	@Test
 	public void createEachWhitePieceTypeExpectMatchingTypeAndColor() {
 		for (PieceType type : PieceType.values()) {


### PR DESCRIPTION
addresses yijis week 10 feedback on missing coverage for Piece.candidateMoves. adds stub subclass + 3 tests for null gaurds and the deafult empty return