### PR TITLE
feat: legal move enforcement (no moving into check)

### DIFF
--- a/src/main/java/domain/Game.java
+++ b/src/main/java/domain/Game.java
@@ -1,5 +1,9 @@
 package domain;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import java.util.Objects;
 import java.util.Optional;
 
@@ -51,6 +55,24 @@ public final class Game {
 			return Optional.of(Color.WHITE);
 		}
 		return Optional.empty();
+	}
+
+	public Set<Square> legalMovesFrom(Square from) {
+		Objects.requireNonNull(from);
+		Optional<Piece> piece = board.pieceAt(from);
+		if (piece.isEmpty()) {
+			return Collections.emptySet();
+		}
+		Color color = piece.get().color();
+		Set<Square> moves = new HashSet<>();
+		for (Square to : piece.get().candidateMoves(from, board)) {
+			Board simulated = board.copy();
+			simulated.move(from, to);
+			if (!isInCheckOn(simulated, color)) {
+				moves.add(to);
+			}
+		}
+		return Collections.unmodifiableSet(moves);
 	}
 
 	public boolean isInCheck(Color color) {
@@ -149,6 +171,11 @@ public final class Game {
 			.orElseThrow(() -> new IllegalStateException("No piece at source square"));
 		if (piece.color() != currentTurn) {
 			throw new IllegalStateException("Not your turn");
+		}
+		Board simulated = board.copy();
+		simulated.move(from, to);
+		if (isInCheckOn(simulated, currentTurn)) {
+			throw new IllegalStateException("Move would leave own king in check");
 		}
 		board.move(from, to);
 		Color moved = currentTurn;

--- a/src/main/java/ui/BoardPanel.java
+++ b/src/main/java/ui/BoardPanel.java
@@ -54,19 +54,19 @@ public class BoardPanel extends JPanel {
 
 	private void handleClick(Square clickedSquare) {
 		if (selectedSquare != null) {
-			Optional<Piece> picked = board.pieceAt(selectedSquare);
-			if (picked.isPresent()) {
-				Set<Square> dests = picked.get()
-					.candidateMoves(selectedSquare, board);
-				if (dests.contains(clickedSquare)) {
+			Set<Square> legalDests = game.legalMovesFrom(selectedSquare);
+			if (legalDests.contains(clickedSquare)) {
+				try {
 					game.makeMove(selectedSquare, clickedSquare);
 					if (game.canPromote(clickedSquare)) {
 						showPromotionDialog(clickedSquare);
 					}
-					selectedSquare = null;
-					repaint();
-					return;
+				} catch (IllegalStateException ex) {
+					JOptionPane.showMessageDialog(this, ex.getMessage());
 				}
+				selectedSquare = null;
+				repaint();
+				return;
 			}
 		}
 		Optional<Piece> clickedPiece = board.pieceAt(clickedSquare);
@@ -150,11 +150,7 @@ public class BoardPanel extends JPanel {
 		if (selectedSquare == null) {
 			return Collections.emptySet();
 		}
-		Optional<Piece> piece = board.pieceAt(selectedSquare);
-		if (!piece.isPresent()) {
-			return Collections.emptySet();
-		}
-		return piece.get().candidateMoves(selectedSquare, board);
+		return game.legalMovesFrom(selectedSquare);
 	}
 
 	private void paintSquare(Graphics g, int file, int rank,

--- a/src/test/java/domain/GameTest.java
+++ b/src/test/java/domain/GameTest.java
@@ -436,4 +436,33 @@ public class GameTest {
 		Assertions.assertThrows(
 			NullPointerException.class, () -> game.legalMovesFrom(null));
 	}
+
+	@Test
+	public void legalMovesFromExcludesMoveThatExposesKing() {
+		Board boardMock = EasyMock.createMock(Board.class);
+		Piece whiteKnightMock = getMockedPiece(Color.WHITE, PieceType.KNIGHT);
+		Piece blackRookMock = getMockedPiece(Color.BLACK, PieceType.ROOK);
+
+		EasyMock.expect(boardMock.pieceAt(Square.of(1, 0)))
+			.andReturn(Optional.of(whiteKnightMock));
+		EasyMock.expect(whiteKnightMock.candidateMoves(Square.of(1, 0), boardMock))
+			.andReturn(Set.of(Square.of(2, 2)));
+		EasyMock.expect(boardMock.copy()).andStubReturn(boardMock);
+		boardMock.move(Square.of(1, 0), Square.of(2, 2));
+		EasyMock.expectLastCall();
+		EasyMock.expect(boardMock.findKing(Color.WHITE))
+			.andStubReturn(Square.of(4, 0));
+		EasyMock.expect(boardMock.occupiedSquaresOf(Color.BLACK))
+			.andStubReturn(Set.of(Square.of(4, 7)));
+		EasyMock.expect(boardMock.pieceAt(Square.of(4, 7)))
+			.andStubReturn(Optional.of(blackRookMock));
+		EasyMock.expect(blackRookMock.candidateMoves(Square.of(4, 7), boardMock))
+			.andStubReturn(Set.of(Square.of(4, 0)));
+
+		EasyMock.replay(boardMock, whiteKnightMock, blackRookMock);
+		Game game = new Game(boardMock);
+
+		Assertions.assertTrue(game.legalMovesFrom(Square.of(1, 0)).isEmpty());
+		EasyMock.verify(boardMock);
+	}
 }

--- a/src/test/java/domain/GameTest.java
+++ b/src/test/java/domain/GameTest.java
@@ -414,4 +414,17 @@ public class GameTest {
 		EasyMock.expect(mockedPiece.type()).andStubReturn(type);
 		return mockedPiece;
 	}
+
+	// tests for legal-move-enforcement
+	@Test
+	public void legalMovesFromEmptySquareReturnsEmptySet() {
+		Board boardMock = EasyMock.createMock(Board.class);
+		EasyMock.expect(boardMock.pieceAt(Square.of(3, 3)))
+			.andReturn(Optional.empty());
+		EasyMock.replay(boardMock);
+		Game game = new Game(boardMock);
+
+		Assertions.assertTrue(game.legalMovesFrom(Square.of(3, 3)).isEmpty());
+		EasyMock.verify(boardMock);
+	}
 }

--- a/src/test/java/domain/GameTest.java
+++ b/src/test/java/domain/GameTest.java
@@ -465,4 +465,29 @@ public class GameTest {
 		Assertions.assertTrue(game.legalMovesFrom(Square.of(1, 0)).isEmpty());
 		EasyMock.verify(boardMock);
 	}
+
+	@Test
+	public void legalMovesFromIncludesMoveThatKeepsKingSafe() {
+		Board boardMock = EasyMock.createMock(Board.class);
+		Piece whiteKnightMock = getMockedPiece(Color.WHITE, PieceType.KNIGHT);
+
+		EasyMock.expect(boardMock.pieceAt(Square.of(1, 0)))
+			.andReturn(Optional.of(whiteKnightMock));
+		EasyMock.expect(whiteKnightMock.candidateMoves(Square.of(1, 0), boardMock))
+			.andReturn(Set.of(Square.of(2, 2)));
+		EasyMock.expect(boardMock.copy()).andStubReturn(boardMock);
+		boardMock.move(Square.of(1, 0), Square.of(2, 2));
+		EasyMock.expectLastCall();
+		EasyMock.expect(boardMock.findKing(Color.WHITE))
+			.andStubReturn(Square.of(4, 0));
+		EasyMock.expect(boardMock.occupiedSquaresOf(Color.BLACK))
+			.andStubReturn(Set.of());
+
+		EasyMock.replay(boardMock, whiteKnightMock);
+		Game game = new Game(boardMock);
+
+		Set<Square> legal = game.legalMovesFrom(Square.of(1, 0));
+		Assertions.assertTrue(legal.contains(Square.of(2, 2)));
+		EasyMock.verify(boardMock);
+	}
 }

--- a/src/test/java/domain/GameTest.java
+++ b/src/test/java/domain/GameTest.java
@@ -490,4 +490,33 @@ public class GameTest {
 		Assertions.assertTrue(legal.contains(Square.of(2, 2)));
 		EasyMock.verify(boardMock);
 	}
+
+	@Test
+	public void makeMoveRejectsMoveLeavingOwnKingInCheck() {
+		Board boardMock = EasyMock.createMock(Board.class);
+		Piece whiteKnightMock = getMockedPiece(Color.WHITE, PieceType.KNIGHT);
+		Piece blackRookMock = getMockedPiece(Color.BLACK, PieceType.ROOK);
+
+		EasyMock.expect(boardMock.pieceAt(Square.of(1, 0)))
+			.andReturn(Optional.of(whiteKnightMock));
+		EasyMock.expect(boardMock.copy()).andStubReturn(boardMock);
+		boardMock.move(Square.of(1, 0), Square.of(2, 2));
+		EasyMock.expectLastCall();
+		EasyMock.expect(boardMock.findKing(Color.WHITE))
+			.andStubReturn(Square.of(4, 0));
+		EasyMock.expect(boardMock.occupiedSquaresOf(Color.BLACK))
+			.andStubReturn(Set.of(Square.of(4, 7)));
+		EasyMock.expect(boardMock.pieceAt(Square.of(4, 7)))
+			.andStubReturn(Optional.of(blackRookMock));
+		EasyMock.expect(blackRookMock.candidateMoves(Square.of(4, 7), boardMock))
+			.andStubReturn(Set.of(Square.of(4, 0)));
+
+		EasyMock.replay(boardMock, whiteKnightMock, blackRookMock);
+		Game game = new Game(boardMock);
+
+		Assertions.assertThrows(
+			IllegalStateException.class,
+			() -> game.makeMove(Square.of(1, 0), Square.of(2, 2)));
+		EasyMock.verify(boardMock);
+	}
 }

--- a/src/test/java/domain/GameTest.java
+++ b/src/test/java/domain/GameTest.java
@@ -427,4 +427,13 @@ public class GameTest {
 		Assertions.assertTrue(game.legalMovesFrom(Square.of(3, 3)).isEmpty());
 		EasyMock.verify(boardMock);
 	}
+
+	@Test
+	public void legalMovesFromNullSquareThrows() {
+		Board boardMock = EasyMock.createMock(Board.class);
+		Game game = new Game(boardMock);
+
+		Assertions.assertThrows(
+			NullPointerException.class, () -> game.legalMovesFrom(null));
+	}
 }

--- a/src/test/java/domain/GameTest.java
+++ b/src/test/java/domain/GameTest.java
@@ -32,7 +32,7 @@ public class GameTest {
 		EasyMock.expect(boardMock.pieceAt(Square.of(1, 0))).andReturn(
 				Optional.of(whiteKnightMock));
 		boardMock.move(Square.of(1, 0), Square.of(2, 2));
-		EasyMock.expectLastCall();
+		EasyMock.expectLastCall().times(2);
 		EasyMock.expect(boardMock.pieceAt(Square.of(2, 2))).andReturn(
 				Optional.of(whiteKnightMock)).times(4);
 		// These stubs are generally irrelevant to the result, only to ensure
@@ -43,6 +43,9 @@ public class GameTest {
 		EasyMock.expect(boardMock.occupiedSquaresOf(Color.BLACK)).andStubReturn(Set.of());
 		EasyMock.expect(whiteKnightMock.candidateMoves(Square.of(2, 2), boardMock))
 		        .andStubReturn(Set.of());
+
+		EasyMock.expect(boardMock.copy()).andStubReturn(boardMock);
+		EasyMock.expect(boardMock.findKing(Color.WHITE)).andStubReturn(Square.of(4, 0));
 
 		EasyMock.replay(boardMock, whiteKnightMock);
 


### PR DESCRIPTION
rejects moves that leave your own king in check. legalMovesFrom filters them out and BoardPanel only shows and allows legal moves now, so a pinned peice cant move off the pin