### PR TITLE
castling rights fix

### DIFF
--- a/src/main/java/domain/Game.java
+++ b/src/main/java/domain/Game.java
@@ -332,7 +332,10 @@ public final class Game {
 				board.move(from, to);
 			}
 		}
+
 		movedFrom.add(from);
+		movedFrom.add(to);
+
 		lastMove = new LastMove(piece.type(), piece.color(), from, to);
 		Color moved = currentTurn;
 		currentTurn = currentTurn.opposite();


### PR DESCRIPTION
castling right is now lost when the original rook is captured on its home square, not just when it moves. addresses jace's review.